### PR TITLE
Expose legacyPackages attribute

### DIFF
--- a/per-system.nix
+++ b/per-system.nix
@@ -125,6 +125,8 @@
 
         };
 
+        legacyPackages = pkgs;
+
       };
 
   })


### PR DESCRIPTION
Allows using nixpkgs with nix-extra overlay added.
