### PR TITLE
Add pandoc-with-nos

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2993,6 +2993,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-pandoc": {
+      "locked": {
+        "lastModified": 1653936696,
+        "narHash": "sha256-M6bJShji9AIDZ7Kh7CPwPBPb/T7RiVev2PAcOi4fxDQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ce6aa13369b667ac2542593170993504932eb836",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-petsc": {
       "locked": {
         "lastModified": 1688556768,
@@ -4014,6 +4030,7 @@
         "nixpkgs-fractopo": "nixpkgs-fractopo",
         "nixpkgs-gpt-engineer": "nixpkgs-gpt-engineer",
         "nixpkgs-kibitzr": "nixpkgs-kibitzr",
+        "nixpkgs-pandoc": "nixpkgs-pandoc",
         "nixpkgs-petsc": "nixpkgs-petsc",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "pandera-src": "pandera-src",

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,8 @@
       "github:nixos/nixpkgs/5efc8ca954272c4376ac929f4c5ffefcc20551d5";
     # TODO: pygeos was removed in nixos-24.05
     nixpkgs-fractopo.url = "github:nixos/nixpkgs/nixos-23.11";
+    # For use with pandox-xnos and friends
+    nixpkgs-pandoc = { url = "github:nixos/nixpkgs/22.05"; };
     # Use flake-utils for utility functions
     flake-utils = { url = "github:numtide/flake-utils"; };
     # TODO: Failed 15.1.2024. Probably will be fixed soon.


### PR DESCRIPTION
Version >=3 of pandoc is no longer compatible with pandoc-xnos
with some outputs, notably docx. Use of pandoc 2 with these packages
is more compatible.
