### PR TITLE
Add nix flake remote eval and build script

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -199,6 +199,9 @@ in {
     '';
   };
 
+  nix-flake-remote-eval-and-build =
+    prev.callPackage ./packages/nix-flake-remote-eval-and-build.nix { };
+
   pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
     (python-final: python-prev: {
       sphinxcontrib-mermaid =

--- a/overlays/packages/nix-flake-remote-eval-and-build.nix
+++ b/overlays/packages/nix-flake-remote-eval-and-build.nix
@@ -1,0 +1,16 @@
+{ writeShellApplication, jq }:
+
+let
+  app = writeShellApplication {
+    name = "nix-flake-remote-eval-and-build";
+    runtimeInputs = [ jq ];
+    text = ''
+      flakepath="$(nix flake metadata --json | jq -r '.path')"
+      host="$1"
+      buildtarget="$2"
+      nix flake archive --to ssh://"$host"
+      ssh "$host" -- nix build "$flakepath"#"$buildtarget"
+    '';
+
+  };
+in app

--- a/per-system.nix
+++ b/per-system.nix
@@ -36,7 +36,8 @@
             sync-git-tag-with-poetry resolve-version poetry-run
             python39-with-c-tooling python310-with-c-tooling
             python311-with-c-tooling jupytext-nb-edit template-check nvim-nixvim
-            git-history-grep gdal update-flake fhs fhs-no-ld;
+            git-history-grep gdal update-flake fhs fhs-no-ld
+            nix-flake-remote-eval-and-build;
           inherit (pkgs.python3Packages)
             doit-ext sphinxcontrib-mermaid sphinx-gallery item-synchronizer
             powerlaw python-ternary mplstereonet pyvtk fractopo


### PR DESCRIPTION
Script to use nix flake archive and ssh to evaluate and build on a
remote machine directly using local flake source.
